### PR TITLE
Properly generates plural translations when there are at maximum 2 plural translations

### DIFF
--- a/potx.drush.inc
+++ b/potx.drush.inc
@@ -26,6 +26,7 @@ function potx_drush_command() {
       'folder' => 'Folder to begin translation extraction in. When no other option is set this defaults to current directory.',
       'api' => 'Drupal core version to use for extraction settings.',
       'language' => 'language to include in the po file',
+      'destination' => 'The file name of the exported file.',
     ),
     'examples' => array(
       'potx single' => 'Extract translatable strings from applicable files in current directory and write to single output file',

--- a/potx.drush.inc
+++ b/potx.drush.inc
@@ -97,6 +97,8 @@ function potx_drush_extract($mode = NULL) {
     $folder_option = drush_get_option('folder');
     $api_option = drush_get_option('api');
     $language_option = drush_get_option('language');
+    $destination = drush_get_option('destination');
+
     if (empty($api_option) || !in_array($api_option, [5, 6, 7, 8])) {
       $api_option = POTX_API_CURRENT;
     }
@@ -128,14 +130,14 @@ function potx_drush_extract($mode = NULL) {
     potx_finish_processing('_potx_save_string', $api_option);
 
     _potx_build_files(
-      POTX_STRING_RUNTIME,
-      $build_mode,
-      'general',
-      '_potx_save_string',
-      '_potx_save_version',
-      '_potx_get_header',
-      $language_option,
-      $language_option
+        POTX_STRING_RUNTIME,
+        $build_mode,
+        $destination,
+        '_potx_save_string',
+        '_potx_save_version',
+        '_potx_get_header',
+        $language_option,
+        $language_option
     );
     _potx_build_files(POTX_STRING_INSTALLER, POTX_BUILD_SINGLE, 'installer');
     _potx_write_files();

--- a/potx.inc
+++ b/potx.inc
@@ -611,9 +611,8 @@ function _potx_translation_export($translation_export_langcode, $string, $plural
     // String with plural variants. Fill up source string array first.
     $plural = stripcslashes($plural);
     $strings = array();
-    $number_of_plurals = db_table_exists('{'. $language_table . '}') ?
-      db_query('SELECT plurals FROM {'. $language_table ."} WHERE {$language_column} = :langcode", array(':langcode' => $translation_export_langcode))->fetchField() :
-      0;
+    // Hard-codes number of plurals to 2.
+    $number_of_plurals = 2;
     $plural_index = 0;
     while ($plural_index < $number_of_plurals) {
       if ($plural_index == 0) {
@@ -627,21 +626,17 @@ function _potx_translation_export($translation_export_langcode, $string, $plural
       else {
         // More plural versions only if required, with the lookup source
         // string modified as imported into the database.
-        $strings[] = str_replace('@count', '@count['. $plural_index .']', $plural);
+        $strings[] = str_replace('@count', '@count[' . $plural_index . ']', $plural);
       }
       $plural_index++;
     }
 
     $output = '';
-    if (count($strings)) {
-      // Source string array was done, so export translations.
+    // If there are plural translations, iterates through them and saves them.
+    if (count($strings) && ($translation = db_query("SELECT t.translation FROM {locales_source} s LEFT JOIN {locales_target} t ON t.lid = s.lid WHERE s.source = :source AND t.{$language_column} = :langcode", array(':source' => $string . "\x03" . $plural, ':langcode' => $translation_export_langcode))->fetchField())) {
       foreach ($strings as $index => $string) {
-        if ($translation = db_query("SELECT t.translation FROM {locales_source} s LEFT JOIN {locales_target} t ON t.lid = s.lid WHERE s.source = :source AND t.{$language_column} = :langcode", array(':source' => $string, ':langcode' => $translation_export_langcode))->fetchField()) {
-          $output .= 'msgstr['. $index .'] '. _locale_export_string(_locale_export_remove_plural($translation));
-        }
-        else {
-          $output .= "msgstr[". $index ."] \"\"\n";
-        }
+        print "\n" . $translation . "\n" . $index . "\n";
+        $output .= 'msgstr[' . $index . '] ' . _locale_export_string(explode("\x03", $translation)[$index]);
       }
     }
     else {

--- a/potx.inc
+++ b/potx.inc
@@ -684,7 +684,7 @@ function _potx_get_header($file, $template_export_langcode = NULL, $api_version 
     $output .= "\"Plural-Forms: nplurals=". $language->plurals ."; plural=". strtr($language->formula, array('$' => '')) .";\\n\"\n\n";
   }
   else {
-    $output .= "\"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\\n\"\n\n";
+    $output .= "\"Plural-Forms: nplurals=2; plural=(n!=1);\\n\"\n\n";
   }
   return $output;
 }

--- a/src/Commands/PotxCommands.php
+++ b/src/Commands/PotxCommands.php
@@ -30,6 +30,7 @@ class PotxCommands extends DrushCommands
      *   option is set this defaults to current directory.
      * @option api Drupal core version to use for extraction settings.
      * @option language Language to include in the po file
+     * @option destination The file name of the exported file.
      *
      * @usage potx single
      *   Extract translatable strings from applicable files in current
@@ -52,6 +53,7 @@ class PotxCommands extends DrushCommands
             'folder' => null,
             'api' => null,
             'language' => null,
+            'destination' => 'general',
           ]
     ) {
         // Include library.
@@ -75,6 +77,7 @@ class PotxCommands extends DrushCommands
         $folder_option = $options['folder'];
         $api_option = $options['api'];
         $language_option = $options['language'];
+        $destination = $options['destination'];
         if (empty($api_option) || !in_array($api_option, [5, 6, 7, 8])) {
             $api_option = POTX_API_CURRENT;
         }
@@ -122,7 +125,7 @@ class PotxCommands extends DrushCommands
         _potx_build_files(
             POTX_STRING_RUNTIME,
             $build_mode,
-            'general',
+            $destination,
             '_potx_save_string',
             '_potx_save_version',
             '_potx_get_header',


### PR DESCRIPTION
The code wasn't generating plural translations, this pull request alters it so it'll work within specific needs.

It's being hardcoded for 2 plural translations so that we don't need to bootstrap Drupal to read language-related configurations and for now this isn't a priotity.