### PR TITLE
Corrige Plural-Forms corrompido, assumindo um plural 2 por default

### DIFF
--- a/potx.inc
+++ b/potx.inc
@@ -684,7 +684,7 @@ function _potx_get_header($file, $template_export_langcode = NULL, $api_version 
     $output .= "\"Plural-Forms: nplurals=". $language->plurals ."; plural=". strtr($language->formula, array('$' => '')) .";\\n\"\n\n";
   }
   else {
-    $output .= "\"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\\n\"\n\n";
+    $output .= "\"Plural-Forms: nplurals=2; plural=(n!=1);\\n\"\n\n";
   }
   return $output;
 }


### PR DESCRIPTION
chuva-inc/sucesso-do-cliente#1818: 