### PR TITLE
Atualiza potx para Drupal 9

### DIFF
--- a/potx.inc
+++ b/potx.inc
@@ -30,8 +30,10 @@ spl_autoload_register(function($c){
 });
 
 use Drupal\Component\Gettext\PoItem;
+use Drupal\Core\Template\Loader\FilesystemLoader;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
+use Twig\Source;
 
 /**
  * The current Drupal major API verion.
@@ -1798,10 +1800,30 @@ function _potx_parse_js_string($string) {
  * Parse a Twig template for translatables. Drupal 8+.
  */
 function _potx_parse_twig_file($code, $file, $save_callback) {
-  $twig_lexer = new Twig_Lexer(new Twig_Environment());
+  $is_twig_1 = TRUE;
+  $twig_lexer = NULL;
+  try {
+    $twig_lexer = new Twig_Lexer(new Twig_Environment());
+  }
+  catch (ArgumentCountError $e) {
+    // Probably means we need to use the syntax for twig 2.
+    $is_twig_1 = FALSE;
+  }
+  if (!$twig_lexer) {
+    $module_handler = \Drupal::moduleHandler();
+    $theme_handler = \Drupal::service('theme_handler');
+    $loader = new FilesystemLoader($file, $module_handler, $theme_handler);
+    $twig_lexer = new Twig_Lexer(new Twig_Environment($loader));
+  }
 
   try {
-    $stream = $twig_lexer->tokenize($code, $file);
+    if ($is_twig_1) {
+      $stream = $twig_lexer->tokenize($code, $file);
+    }
+    else {
+      $source = new Source($code, $file);
+      $stream = $twig_lexer->tokenize($source);
+    }
   } catch(Twig_Error_Syntax $e) {
     potx_status('error', t("Twig parsing error on file @path: @error", array(
         '@path' => $file,

--- a/potx.inc
+++ b/potx.inc
@@ -688,9 +688,6 @@ function _potx_get_header($file, $template_export_langcode = NULL, $api_version 
   if (isset($language->formula) && isset($language->plurals)) {
     $output .= "\"Plural-Forms: nplurals=". $language->plurals ."; plural=". strtr($language->formula, array('$' => '')) .";\\n\"\n\n";
   }
-  else {
-    $output .= "\"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\\n\"\n\n";
-  }
   return $output;
 }
 

--- a/potx.inc
+++ b/potx.inc
@@ -29,6 +29,7 @@ spl_autoload_register(function($c){
   @include preg_replace('#\\\|_(?!.*\\\)#','/',$c).'.php';
 });
 
+use Drupal\Component\Gettext\PoItem;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
 
@@ -514,8 +515,12 @@ function _potx_build_files($string_mode = POTX_STRING_RUNTIME, $build_mode = POT
         if (!empty($context)) {
           $output .= "msgctxt \"$context\"\n";
         }
-        $output .= "msgid \"$singular\"\n";
-        $output .= "msgid_plural \"$plural\"\n";
+        // If this class exists, the msgid header part will be outputted by the
+        // item class iteself.
+        if (!class_exists('Drupal\Component\Gettext\PoItem')) {
+          $output .= "msgid \"$singular\"\n";
+          $output .= "msgid_plural \"$plural\"\n";
+        }
         if (isset($translation_export_langcode)) {
           if (!empty($context) && $core_version_major >= 7) {
             $output .= _potx_translation_export($translation_export_langcode, $singular, $plural, $api_version, $context);
@@ -591,15 +596,18 @@ function _potx_translation_export($translation_export_langcode, $string, $plural
 
   // Column and table name changed between versions.
   $language_column = $api_version > POTX_API_5 ? 'language' : 'locale';
-  $language_table  = $api_version > POTX_API_5 ? 'languages' : 'locales_meta';
+  /** @var \Drupal\Core\Database\Connection $database */
+  $database = \Drupal::service('database');
+  /** @var \Drupal\locale\PluralFormulaInterface $plural_formula */
+  $plural_formula = \Drupal::service('locale.plural.formula');
 
   if (!isset($plural)) {
     // Single string to look translation up for.
     if (!empty($context)) {
-      $translation = db_query("SELECT t.translation FROM {locales_source} s LEFT JOIN {locales_target} t ON t.lid = s.lid WHERE s.source = :source AND t.{$language_column} = :langcode AND context = :context", array(':source' => $string, ':langcode' => $translation_export_langcode, ':context' => $context))->fetchField();
+      $translation = $database->query("SELECT t.translation FROM {locales_source} s LEFT JOIN {locales_target} t ON t.lid = s.lid WHERE s.source = :source AND t.{$language_column} = :langcode AND context = :context", array(':source' => $string, ':langcode' => $translation_export_langcode, ':context' => $context))->fetchField();
     }
     else {
-      $translation = db_query("SELECT t.translation FROM {locales_source} s LEFT JOIN {locales_target} t ON t.lid = s.lid WHERE s.source = :source AND t.{$language_column} = :langcode", array(':source' => $string, ':langcode' => $translation_export_langcode))->fetchField();
+      $translation = $database->query("SELECT t.translation FROM {locales_source} s LEFT JOIN {locales_target} t ON t.lid = s.lid WHERE s.source = :source AND t.{$language_column} = :langcode", array(':source' => $string, ':langcode' => $translation_export_langcode))->fetchField();
     }
     if ($translation) {
       return 'msgstr '. _locale_export_string($translation);
@@ -611,9 +619,7 @@ function _potx_translation_export($translation_export_langcode, $string, $plural
     // String with plural variants. Fill up source string array first.
     $plural = stripcslashes($plural);
     $strings = array();
-    $number_of_plurals = db_table_exists('{'. $language_table . '}') ?
-      db_query('SELECT plurals FROM {'. $language_table ."} WHERE {$language_column} = :langcode", array(':langcode' => $translation_export_langcode))->fetchField() :
-      0;
+    $number_of_plurals = $plural_formula->getNumberOfPlurals($translation_export_langcode);
     $plural_index = 0;
     while ($plural_index < $number_of_plurals) {
       if ($plural_index == 0) {
@@ -635,13 +641,11 @@ function _potx_translation_export($translation_export_langcode, $string, $plural
     $output = '';
     if (count($strings)) {
       // Source string array was done, so export translations.
-      foreach ($strings as $index => $string) {
-        if ($translation = db_query("SELECT t.translation FROM {locales_source} s LEFT JOIN {locales_target} t ON t.lid = s.lid WHERE s.source = :source AND t.{$language_column} = :langcode", array(':source' => $string, ':langcode' => $translation_export_langcode))->fetchField()) {
-          $output .= 'msgstr['. $index .'] '. _locale_export_string(_locale_export_remove_plural($translation));
-        }
-        else {
-          $output .= "msgstr[". $index ."] \"\"\n";
-        }
+      $combined_string = implode($strings, PoItem::DELIMITER);
+      if ($values = $database->query("SELECT t.*,s.* FROM {locales_source} s LEFT JOIN {locales_target} t ON t.lid = s.lid WHERE s.source = :source AND t.{$language_column} = :langcode", array(':source' => $combined_string, ':langcode' => $translation_export_langcode))->fetchAssoc()) {
+        $po_item = new PoItem();
+        $po_item->setFromArray($values);
+        $output .= (string) $po_item;
       }
     }
     else {

--- a/potx.info.yml
+++ b/potx.info.yml
@@ -1,6 +1,7 @@
 name: Translation template extractor
 description: Provides a web interface and an API to extract translatable text from the sources of installed components.
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: Multilingual
 version: 8.x-1.x-dev
 dependencies:

--- a/src/Commands/PotxCommands.php
+++ b/src/Commands/PotxCommands.php
@@ -127,7 +127,8 @@ class PotxCommands extends DrushCommands
             '_potx_save_version',
             '_potx_get_header',
             $language_option,
-            $language_option
+            $language_option,
+            $api_option
         );
         _potx_build_files(POTX_STRING_INSTALLER, POTX_BUILD_SINGLE, 'installer');
         _potx_write_files();


### PR DESCRIPTION
* Estou considerando `chuva-potx` como a branch "master" deste repo
* Este PR basicamente importa as alterações feitas no PR https://github.com/kgaut/drupal-potx/pull/19/files
* Aplica também o patch `potx-remove-noisy-header.patch` que vivia nos repositórios dos predinhos

Passos para gerar este PR:

```
git checkout chuva-potx
git checkout -b galoc-eventmanager-2357-potx-d9
git remote add eiriksm git@github.com:eiriksm/drupal-potx.git
git merge eiriksm/fix/d9
```

(um erro de merge aconteceu nesse processo, foi corrigido)

E para o patch:

```
git apply potx-remove-noisy-header.patch
git add -p potx.inc
git commit -m 'Aplica patch potx-remove-noisy-header.patch'
```